### PR TITLE
added side margins for text

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -7,17 +7,25 @@
         h1 {
             font-size: 24px; 
             font-weight: bold;
+            margin-left: 70px;
+            margin-right: 70px;
         }
         h2 {
             font-size: 18px;
-            font-weight: bold;
+            font-weight: bold;.
+            margin-left: 70px;
+            margin-right: 70px;
         }
         h3 {
             font-size: 14px;
             font-weight: bold;
+            margin-left: 70px;
+            margin-right: 70px;
         }
         p {
             font-size: 12px;
+            margin-left: 70px;
+            margin-right: 70px;
         }
     </style>
 </head>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -7,17 +7,25 @@
         h1 {
             font-size: 24px; 
             font-weight: bold;
+            margin-left: 70px;
+            margin-right: 70px;
         }
         h2 {
             font-size: 18px;
             font-weight: bold;
+            margin-left: 70px;
+            margin-right: 70px;
         }
         h3 {
             font-size: 14px;
             font-weight: bold;
+            margin-left: 70px;
+            margin-right: 70px;
         }
         p {
             font-size: 12px;
+            margin-left: 70px;
+            margin-right: 70px;
         }
     </style>
 </head>


### PR DESCRIPTION
User Story:
As a user, I would like the site's text boxes to be less close to the sides so that the site looks cleaner.

Acceptance Criteria:
- All text fields have margins so that they don't bleed to the edge of the window.